### PR TITLE
Add temporary override for active release

### DIFF
--- a/get-lms-release/lms-version-helper.js
+++ b/get-lms-release/lms-version-helper.js
@@ -76,6 +76,7 @@ async function tryGetActiveDevelopmentRelease(api_key) {
 	}
 
 	let activeReleaseName = release.Name;
+	activeReleaseName = '20.22.06';
 
 	const match = rallyVersionChecker.exec(activeReleaseName);
 	if (!match) {


### PR DESCRIPTION
We're releasing a day early, and Rally is returning `20.22.5` still.  This can be removed after noon tomorrow, and needs to be done before the next release.