### PR TITLE
Remove temporary release override

### DIFF
--- a/get-lms-release/lms-version-helper.js
+++ b/get-lms-release/lms-version-helper.js
@@ -76,7 +76,6 @@ async function tryGetActiveDevelopmentRelease(api_key) {
 	}
 
 	let activeReleaseName = release.Name;
-	activeReleaseName = '20.22.06';
 
 	const match = rallyVersionChecker.exec(activeReleaseName);
 	if (!match) {


### PR DESCRIPTION
We should be good to remove this now that we're in the 20.22.6 release according to Rally