### PR TITLE
Add auto release note generation

### DIFF
--- a/match-lms-release/create-release.js
+++ b/match-lms-release/create-release.js
@@ -15,7 +15,8 @@ async function createRelease() {
 		owner: owner,
 		repo: repo,
 		tag_name: release,
-		name: release
+		name: release,
+		generate_release_notes: true
 	});
 	console.log('Success!');
 


### PR DESCRIPTION
Whether to automatically generate the name and body for this release. If `name` is specified, the specified `name` will be used; otherwise, a `name` will be automatically generated. If `body` is specified, the `body` will be pre-pended to the automatically generated notes.

Same change made for incremental release https://github.com/BrightspaceUI/actions/pull/62.