### PR TITLE
Allow backport message format to include  `release/`

### DIFF
--- a/backport/README.md
+++ b/backport/README.md
@@ -1,10 +1,15 @@
 # Backport Action
 
-This GitHub action automatically cherry-picks the commits from a PR to open a new PR against a maintenance branch for backporting. Maintenance branches must begin with the prefix `release/` (ie `release/2022.1.x`)
+This GitHub action automatically cherry-picks the commits from a PR to open a
+new PR against a maintenance branch for backporting. Maintenance branches must
+begin with the prefix `release/` (ie `release/2022.1.x`).
 
 ## Using the Action
 
-This action should be triggered from a workflow that runs on PR comments of the format `/backport <maintenance-branch-name>` - ie `/backport 2022.1.x` to create a backport pr to a branch named `release/2022.1.x`
+This action should be triggered from a workflow that runs on PR comments of the
+format `/backport <maintenance-branch-name>` - ie `/backport 2022.1.x` or
+`/backport release/2022.1.x` to create a backport PR to a branch named
+`release/2022.1.x`.
 
 Here's a sample backport workflow:
 

--- a/backport/action.yml
+++ b/backport/action.yml
@@ -35,7 +35,10 @@ runs:
         github-token:  ${{ inputs.GITHUB_TOKEN }}
         result-encoding: string
         script: |
-          const version = process.env.BODY.split(' ').pop();
+          let version = process.env.BODY.split(' ').pop();
+          if (version.startsWith('release/')) {
+            version = version.split('/').pop();
+          }
           return version;
 
     #find the branch corresponding to the version we want to backport to (destination branch)


### PR DESCRIPTION
I've seen a number of people type `/backport release/2022.8.x` and be confused that nothing happened. Adding support for this so you can do `/backport release/2022.8.x` or  `/backport 2022.8.x` and both will work.