### PR TITLE
Use passed in `GITHUB_TOKEN` for git commands

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -4,7 +4,7 @@ description: 'Create a backport PR from a source PR back to a specified release 
 
 inputs:
   GITHUB_TOKEN:
-    description: Token to use to update version in 'package.json' and create the tag
+    description: Token to use to create the backport commit and PR
     required: true
 
 runs:
@@ -105,6 +105,7 @@ runs:
     - name: Apply patch and push
       env:
         INPUT_DESTINATION_HEAD_BRANCH: 'ghworkflow/backport-${{ steps.destination-version.outputs.result }}/${{ fromJSON(steps.source-pr.outputs.result).head.ref }}'
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
       run: |
         git config user.name github-actions[bot]
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
@@ -116,7 +117,7 @@ runs:
         git am --keep-cr --signoff << "D2LEOF"
         ${{ steps.source-pr-patch.outputs.result }}
         D2LEOF
-        git push origin $INPUT_DESTINATION_HEAD_BRANCH:$INPUT_DESTINATION_HEAD_BRANCH
+        git push https://${GITHUB_TOKEN}@github.com/${{ github.repository }} $INPUT_DESTINATION_HEAD_BRANCH:$INPUT_DESTINATION_HEAD_BRANCH
       shell: bash
 
     #Open backport PR on destination branch


### PR DESCRIPTION
This should work based on how I've seen/done it in the past. If not I can just revert it. Came across this because we added `contests: read` to all our workflow default permissions and it failed since it's using the default token instead of the passed in one.