### PR TITLE
feat: Use shared tool get-maintenance-version

### DIFF
--- a/match-lms-release/action.yml
+++ b/match-lms-release/action.yml
@@ -43,13 +43,9 @@ runs:
       with:
         RALLY_API_KEY: ${{ inputs.RALLY_API_KEY }}
 
-    - name: Gather Information
-      id: info
-      run: |
-        MAINTENANCE_VERSION=$(echo "${GITHUB_REF##*/}" | grep -Eo "^[0-9]+\.([0-9]+\.)?x$" || true)
-        echo "Maintenance version determined from branch name: $MAINTENANCE_VERSION"
-        echo "::set-output name=MAINTENANCE_VERSION::$MAINTENANCE_VERSION"
-      shell: bash
+    - name: Get maintenance version
+      uses: BrightspaceUI/actions/get-maintenance-version@main
+      id: get-maintenance-version
 
     - name: Update Version
       id: update-version
@@ -65,7 +61,7 @@ runs:
         LATEST_MINOR=$(echo $LATEST_VERSION | sed 's/\.[^.]*$//')
 
         echo running on branch ${GITHUB_REF##*/}
-        if [ "$LMSVER_MATCH" == "$LATEST_MINOR" ] || [ ! -z "${{ steps.info.outputs.MAINTENANCE_VERSION }}" ]; then
+        if [ "$LMSVER_MATCH" == "$LATEST_MINOR" ] || [ ${{ steps.get-maintenance-version.outputs.IS_MAINTENANCE_BRANCH }} == true ]; then
           echo "Patching Version: \"npm version patch\"..."
           NEW_VERSION=$(npm version patch -m "Updated version to %s [skip ci]" | cut -dv -f2)
         else
@@ -105,7 +101,7 @@ runs:
       run: |
         OPTS=""
         [ ${{ inputs.DRY_RUN }} == true ] && OPTS=" --dry-run"
-        [ ! -z "${{ steps.info.outputs.MAINTENANCE_VERSION }}" ] && OPTS="${OPTS} --tag release-${{ steps.info.outputs.MAINTENANCE_VERSION }}"
+        [ ${{ steps.get-maintenance-version.outputs.IS_MAINTENANCE_BRANCH }} == true ] && OPTS="${OPTS} --tag release-${{ steps.get-maintenance-version.outputs.MAINTENANCE_VERSION }}"
 
         echo "Running npm publish with options: ${OPTS}"
         npm publish ${OPTS}


### PR DESCRIPTION
This PR:

- switches `match-lms-release` to use the shared `get-maintenance-version` tool instead of hard-coding it
- should have no functional change

I added [get-maintenance-version](https://github.com/BrightspaceUI/actions/tree/main/get-maintenance-version) back in June and have been meaning to update this to use it since then.

Related Rally: https://rally1.rallydev.com/#/?detail=/userstory/641415440391&fdp=true