### PR TITLE
Fix bug where output doesn't exist

### DIFF
--- a/match-lms-release/action.yml
+++ b/match-lms-release/action.yml
@@ -27,7 +27,7 @@ inputs:
 outputs:
   VERSION:
     description: Version of the new release
-    value: ${{ steps.increment-version.outputs.version }}
+    value: ${{ steps.update-version.outputs.version }}
 
 runs:
   using: composite


### PR DESCRIPTION
On attempting to read the output from this action to identify the version, we were unable to. Looks like this is due to the output looking for `increment-version` which doesn't exist, rather than `update-version`. This should hopefully resolve that.