### PR TITLE
Switch to use token for checkout

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -62,7 +62,7 @@ runs:
       uses: Brightspace/third-party-actions@actions/checkout
       with:
         ref: ${{ fromJSON(steps.destination-branch.outputs.result).name }}
-        persist-credentials: false
+        token: ${{ inputs.GITHUB_TOKEN }}
 
     #add comment to source PR to acknowledge backport process
     - name: Acknowledge comment


### PR DESCRIPTION
Switch to use `token` for checkout action instead of using `persist-credentials: false`. Without this using a generated token that was set-up via repo-settings fails. Tested with a generated, rotating token as well as the `D2L_GITHUB_TOKEN` both work as expected. 