### PR TITLE
Update Backport README

### DIFF
--- a/backport/README.md
+++ b/backport/README.md
@@ -22,7 +22,7 @@ jobs:
   Backport:
     if: github.event.issue.pull_request && startswith(github.event.comment.body, '/backport')
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, AWS]
 
     steps:
       - name: Create Backport PR


### PR DESCRIPTION
This PR is just updating the Backport README file to use `[self-hosted, Linux, AWS]` instead of `ubuntu` for the `runs-on` line.

All of the current uses of this workflow, run on self-hosted runners instead of using `ubuntu`, so it would make sense to update the `README` to be the same.