### PR TITLE
remove reference to D2L_GITHUB_TOKEN

### DIFF
--- a/backport/README.md
+++ b/backport/README.md
@@ -28,5 +28,9 @@ jobs:
       - name: Create Backport PR
         uses: Brightspace/lms-version-actions/backport@main
         with:
-          GITHUB_TOKEN: ${{ secrets.D2L_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.MY_GITHUB_TOKEN }}
 ```
+
+The `GITHUB_TOKEN` is used to open the backport pull request. This token does not need admin privileges, so the standard `secrets.GITHUB_TOKEN` _can_ work.  However, that token [does not trigger additional workflows](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#using-the-github_token-in-a-workflow).  If you use GitHub actions for your CI, you'll want to set up a rotating GitHub token with `contents: write` and `pull_requests: write` permissions in [`repo-settings`](https://github.com/Brightspace/repo-settings) to use instead.
+
+[Learn more about setting up a token with `repo-settings`](https://github.com/Brightspace/repo-settings/blob/main/docs/github-api-tokens.md) and [see an example...](https://github.com/Brightspace/repo-settings/blob/ffc5ff046e6ccda7044e4c5ae7a60f1f290efb7f/repositories/github/BrightspaceUI/core.yaml#L7-L14)


### PR DESCRIPTION
Based [on this from update-package-lock](https://github.com/BrightspaceUI/actions/blob/main/update-package-lock/README.md#setting-github_token), but with a couple modified bits.