### PR TITLE
GAUD-707: pull active version from event calendar

### DIFF
--- a/get-lms-release/README.md
+++ b/get-lms-release/README.md
@@ -4,10 +4,12 @@ This GitHub action retrieves the active development release version of the LMS f
 
 ## Using the Action
 
-Typically this action is triggered from a workflow that runs on your `main` or `master` branch after each commit or pull request merge.
+Typically this action is triggered from a workflow that runs on your `main` branch after each commit or pull request merge.
 
 Inputs:
-* `RALLY_API_KEY`: Key for the RALLY API (used to retrieve active development release)
+* `aws-access-key-id`: Access key id for the role that will read release info
+* `aws-secret-access-key`: Access key secret for the role that will read release info
+* `aws-session-token`: Session token for the role that will read release info
 
 Outputs:
 * `LMS_VERSION`: Will contain the current active development release version

--- a/get-lms-release/action.yml
+++ b/get-lms-release/action.yml
@@ -1,9 +1,14 @@
 name: 'Get LMS Version'
 description: 'Retrieves the current active development version of Brightspace'
 inputs:
+  aws-access-key-id:
+    description: Access key id for the role that will read release info
+  aws-secret-access-key:
+    description: Access key secret for the role that will read release info
+  aws-session-token:
+    description: Session token for the role that will read release info
   RALLY_API_KEY:
     description: 'Token to find active releases in Rally'
-    required: true
 outputs:
   LMS_VERSION:
     description: 'Current active development version of the LMS'
@@ -12,18 +17,113 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Assume role for reading release info
+      if: ${{ inputs.RALLY_API_KEY == '' }}
+      uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
+        aws-region: ca-central-1
+        role-to-assume: "arn:aws:iam::344604240523:role/prd-release-events-reader"
+    - name: Read release info
+      if: ${{ inputs.RALLY_API_KEY == '' }}
+      run: |
+        aws s3api get-object --bucket prd-nqc-release-events-ca-central-1 --key calendar_events.json calendar_events.json
+      shell: bash
+    - name: Get LMS Version (New)
+      id: get-lms-version-new
+      if: ${{ inputs.RALLY_API_KEY == '' }}
+      uses: Brightspace/third-party-actions@actions/github-script
+      with:
+        script: |
+          const fs = require('fs')
+          const eventsStr = fs.readFileSync('./calendar_events.json');
+          const events = JSON.parse(eventsStr);
+          const devDoneEvents = events
+            .filter(e => e.name.indexOf('Dev Done') !== -1)
+            .map(e => {
+              const releaseParts = e.name.substring(0, 8).split('.');
+              const dateParts = e.day.split('-');
+              return {
+                release: `${releaseParts[0]}.${releaseParts[1]}.${parseInt(releaseParts[2])}`,
+                year: parseInt(dateParts[0]),
+                month: parseInt(dateParts[1]),
+                day: parseInt(dateParts[2])
+              };
+            }).sort(e => new Date(e.year, e.month - 1, e.day).getTime());
+
+          const now = new Date();
+          console.log(`Current server date: ${now.toString()}`);
+
+          const nowTorontoDate = now.toLocaleDateString('en-CA', {
+            day: 'numeric',
+            month: 'numeric',
+            year: 'numeric',
+            timeZone: 'America/Toronto'
+          });
+          const nowDateParts = nowTorontoDate.split('-');
+          const nowYear = parseInt(nowDateParts[0]);
+          const nowMonth = parseInt(nowDateParts[1]);
+          const nowDay = parseInt(nowDateParts[2]);
+
+          const nowTorontoTime = now.toLocaleTimeString('en-CA', {
+            hour12: false,
+            hour: 'numeric',
+            minute: 'numeric',
+            second: 'numeric',
+            timeZone: 'America/Toronto'
+          });
+          const nowTimeParts = nowTorontoTime.split(':');
+          const nowHour = parseInt(nowTimeParts[0]);
+
+          console.log(`Current date in Toronto: ${nowTorontoDate} at ${nowTorontoTime}`);
+
+          console.log('Determining the current active Brightspace release...');
+
+          let currentRelease;
+          for (let i = 0; i < devDoneEvents.length; i++) {
+
+            const devDone = devDoneEvents[i];
+            currentRelease = devDone.release;
+
+            const isInFuture = (devDone.year > nowYear) ||
+              (devDone.year === nowYear && devDone.month > nowMonth) ||
+              (devDone.year === nowYear && devDone.month === nowMonth && devDone.day > nowDay);
+            if (isInFuture) {
+              break;
+            }
+
+            const isReleaseDay = (devDone.year === nowYear && devDone.month === nowMonth && devDone.day === nowDay);
+            if (isReleaseDay) {
+              const isBeforeCutoff = (nowHour < 10);
+              if (isBeforeCutoff) {
+                currentRelease = devDone.release;
+              } else {
+                if (i + 1 === devDoneEvents.length) {
+                  core.setFailed(`Release calendar does not contain a release after "${devDone.release}"`);
+                  break;
+                }
+                currentRelease = devDoneEvents[i + 1].release;
+              }
+              console.log(`Today is the release day for "${devDone.release}", but it is ${isBeforeCutoff ? 'before' : 'after'} the branch cuttoff time of 10am EST (approximate ) in Toronto.`);
+              break;
+            }
+
+          }
+
+          console.log(`The current active Brightspace release is: "${currentRelease}".`);
+          core.setOutput('version', currentRelease);
     - name: Get LMS Version
       id: get-lms-version
       run: |
-        VERSION="20.24.6"
         if [ ${RALLY_API_KEY} != "" ]; then
+          VERSION="20.24.6"
           echo "RALLY_API_KEY detected, returning hard-coded release version..."
-        else
-          echo "RALLY_API_KEY is required, failing..."
-          exit 1
         fi
         echo "$VERSION is the active development release."
         echo "version=$VERSION" >> $GITHUB_OUTPUT
       shell: bash
       env:
         RALLY_API_KEY: ${{ inputs.RALLY_API_KEY }}
+        VERSION: ${{ steps.get-lms-version-new.outputs.version }}

--- a/match-lms-release/README.md
+++ b/match-lms-release/README.md
@@ -4,7 +4,7 @@ This GitHub action automatically increments the package version to match a given
 
 ## Using the Action
 
-Typically this action is triggered from a workflow that runs on your `main` or `master` branch after each commit or pull request merge. It requires that the repo have an existing `package.json` with a defined `version` before the first run.
+Typically this action is triggered from a workflow that runs on your `main` branch after each commit or pull request merge. It requires that the repo have an existing `package.json` with a defined `version` before the first run.
 
 Here's a sample release workflow:
 
@@ -29,11 +29,16 @@ jobs:
       - name: Match LMS Release
         uses: Brightspace/lms-version-actions/match-lms-release@main
         with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
-          RALLY_API_KEY: ${{ secrets.RALLY_API_KEY }}
 ```
 
 Options:
+* `aws-access-key-id`: Access key id for the role that will read release info
+* `aws-secret-access-key`: Access key secret for the role that will read release info
+* `aws-session-token`: Session token for the role that will read release info
 * `AUTO_MAINTENANCE_BRANCH` (default: `true`): Automatically create maintenance branches for previous releases. These branches will be named `release/{release version}.x` (ex: `release/2022.1.x`)
 * `DRY_RUN` (default: `false`): Simulates a release but does not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag -- see section below on the release token for more details
@@ -102,8 +107,10 @@ Then pass through the `NPM_TOKEN` secret.
 - name: Match LMS Release
   uses: Brightspace/lms-version-actions/match-lms-release@main
   with:
+    aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    aws-session-token: ${{ secrets.AWS_SESSION_TOKEN }}
     GITHUB_TOKEN: ${{ secrets.D2L_RELEASE_TOKEN }}
-    RALLY_API_KEY: ${{ secrets.RALLY_API_KEY }}
     NPM: true
     NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 ```

--- a/match-lms-release/action.yml
+++ b/match-lms-release/action.yml
@@ -2,6 +2,12 @@ name: Match LMS Release
 description: Create a release based on the current version of Brightspace and the patch version of the consumer
 
 inputs:
+  aws-access-key-id:
+    description: Access key id for the role that will read release info
+  aws-secret-access-key:
+    description: Access key secret for the role that will read release info
+  aws-session-token:
+    description: Session token for the role that will read release info
   DRY_RUN:
     description: Simulates a release but does not actually do one
     default: false
@@ -12,7 +18,6 @@ inputs:
     required: false
   RALLY_API_KEY:
     description: 'API key to find active releases in Rally'
-    required: true
   GITHUB_TOKEN:
     description: Token to use to update version in 'package.json' and create the tag
     required: true
@@ -41,6 +46,9 @@ runs:
     - uses: Brightspace/lms-version-actions/get-lms-release@main
       id: get-lms-version
       with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-session-token: ${{ inputs.aws-session-token }}
         RALLY_API_KEY: ${{ inputs.RALLY_API_KEY }}
 
     - name: Get maintenance version


### PR DESCRIPTION
We can no pull the active LMS development release from Rally, for obvious reasons. The new location (for now) is a JSON file in a S3 bucket which will be manually updated periodically.

This updates the `get-lms-release` and `match-lms-release` actions to optionally use the new non-Rally method. I've tested this out in a downstream repo by manually pointing it at this branch, and things appear to work.

The plan will be:
1. Merge this PR, nothing will change since everything is passing `RALLY_API_KEY`
2. One by one, switch consumers of either action to stop passing `RALLY_API_KEY` and instead pass the appropriate AWS secrets. These will be set automatically via `repo-settings` and the `release_action_setup: true` module.
3. Once everything is switched over, I'll remove support for the "Rally way" from here