### PR TITLE
remove RALLY_API_KEY

### DIFF
--- a/get-lms-release/action.yml
+++ b/get-lms-release/action.yml
@@ -3,12 +3,13 @@ description: 'Retrieves the current active development version of Brightspace'
 inputs:
   aws-access-key-id:
     description: Access key id for the role that will read release info
+    required: true
   aws-secret-access-key:
     description: Access key secret for the role that will read release info
+    required: true
   aws-session-token:
     description: Session token for the role that will read release info
-  RALLY_API_KEY:
-    description: 'Token to find active releases in Rally'
+    required: true
 outputs:
   LMS_VERSION:
     description: 'Current active development version of the LMS'
@@ -18,7 +19,6 @@ runs:
   using: composite
   steps:
     - name: Assume role for reading release info
-      if: ${{ inputs.RALLY_API_KEY == '' }}
       uses: Brightspace/third-party-actions@aws-actions/configure-aws-credentials
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
@@ -27,13 +27,11 @@ runs:
         aws-region: ca-central-1
         role-to-assume: "arn:aws:iam::344604240523:role/prd-release-events-reader"
     - name: Read release info
-      if: ${{ inputs.RALLY_API_KEY == '' }}
       run: |
         aws s3api get-object --bucket prd-nqc-release-events-ca-central-1 --key calendar_events.json calendar_events.json
       shell: bash
-    - name: Get LMS Version (New)
-      id: get-lms-version-new
-      if: ${{ inputs.RALLY_API_KEY == '' }}
+    - name: Get LMS Version
+      id: get-lms-version
       uses: Brightspace/third-party-actions@actions/github-script
       with:
         script: |
@@ -114,16 +112,3 @@ runs:
 
           console.log(`The current active Brightspace release is: "${currentRelease}".`);
           core.setOutput('version', currentRelease);
-    - name: Get LMS Version
-      id: get-lms-version
-      run: |
-        if [ ${RALLY_API_KEY} != "" ]; then
-          VERSION="20.24.6"
-          echo "RALLY_API_KEY detected, returning hard-coded release version..."
-        fi
-        echo "$VERSION is the active development release."
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-      shell: bash
-      env:
-        RALLY_API_KEY: ${{ inputs.RALLY_API_KEY }}
-        VERSION: ${{ steps.get-lms-version-new.outputs.version }}

--- a/match-lms-release/README.md
+++ b/match-lms-release/README.md
@@ -42,7 +42,6 @@ Options:
 * `AUTO_MAINTENANCE_BRANCH` (default: `true`): Automatically create maintenance branches for previous releases. These branches will be named `release/{release version}.x` (ex: `release/2022.1.x`)
 * `DRY_RUN` (default: `false`): Simulates a release but does not actually do one
 * `GITHUB_TOKEN`: Token to use to update version in 'package.json' and create the tag -- see section below on the release token for more details
-* `RALLY_API_KEY`: Key for the RALLY API (used to retrieve active development release)
 * `NPM` (default: `false`): Whether or not to release as an NPM package (see "NPM Package Deployment" below for more info)
 * `NPM_TOKEN` (optional if `NPM` is `false` or publishing to CodeArtifact): Token to publish to NPM (see "NPM Package Deployment" below for more info)
 

--- a/match-lms-release/action.yml
+++ b/match-lms-release/action.yml
@@ -4,10 +4,13 @@ description: Create a release based on the current version of Brightspace and th
 inputs:
   aws-access-key-id:
     description: Access key id for the role that will read release info
+    required: true
   aws-secret-access-key:
     description: Access key secret for the role that will read release info
+    required: true
   aws-session-token:
     description: Session token for the role that will read release info
+    required: true
   DRY_RUN:
     description: Simulates a release but does not actually do one
     default: false
@@ -16,8 +19,6 @@ inputs:
     description: Automatically create maintenance branches when bumping lms releases
     default: true
     required: false
-  RALLY_API_KEY:
-    description: 'API key to find active releases in Rally'
   GITHUB_TOKEN:
     description: Token to use to update version in 'package.json' and create the tag
     required: true
@@ -49,7 +50,6 @@ runs:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-session-token: ${{ inputs.aws-session-token }}
-        RALLY_API_KEY: ${{ inputs.RALLY_API_KEY }}
 
     - name: Get maintenance version
       uses: BrightspaceUI/actions/get-maintenance-version@main


### PR DESCRIPTION
All the repos using `get-lms-release` or `match-lms-release` have been switched to pass the new AWS credentials instead of `RALLY_API_KEY`. This removes support for the Rally API.