### PR TITLE
Add action for determining release branch from LMS build number

### DIFF
--- a/get-release-branch/README.md
+++ b/get-release-branch/README.md
@@ -23,7 +23,7 @@ jobs:
     timeout-minutes: 5
     runs-on: [self-hosted, Linux, AWS]
     steps:
-      - name: Determine branch
+      - name: Get release branch
         uses: Brightspace/lms-version-actions/get-release-branch@main
         id: release
         with:

--- a/get-release-branch/README.md
+++ b/get-release-branch/README.md
@@ -2,7 +2,8 @@
 
 This GitHub action retrieves the corresponding release branch based on the LMS
 build number you supply. If no such branch exists it will return the
-repositories default branch.
+repository's default branch.
+
 
 ## Using the Action
 

--- a/get-release-branch/README.md
+++ b/get-release-branch/README.md
@@ -1,0 +1,45 @@
+# Get Release Branch
+
+This GitHub action retrieves the corresponding release branch based on the LMS
+build number you supply. If no such branch exists it will return the
+repositories default branch.
+
+## Using the Action
+
+Typically this action is used within a workflow that runs on your repository
+default branch (often `main`). Usually when using `workflow_dispatch` event.
+
+```yml
+name: Test
+on:
+  workflow_dispatch:
+    inputs:
+      build-number:
+        description: LMS instance build number
+        required: true
+        type: string
+jobs:
+  test:
+    timeout-minutes: 5
+    runs-on: [self-hosted, Linux, AWS]
+    steps:
+      - name: Determine branch
+        uses: Brightspace/lms-version-actions/get-release-branch@main
+        id: release
+        with:
+          build-number: ${{inputs.build-number}}
+      - name: Checkout
+        uses: Brightspace/third-party-actions@actions/checkout
+        with:
+          ref: ${{steps.release.outputs.branch}}
+```
+
+### Inputs
+
+* `build-number` (required): The LMS build number you are hoping to determine
+  the release branch for.
+
+### Outputs
+
+* `branch`: Will contain the corresponding release branch or repository default
+  branch.

--- a/get-release-branch/action.yml
+++ b/get-release-branch/action.yml
@@ -1,0 +1,52 @@
+name: Get Release Branch
+description: Retrieves the corresponding release branch or repository default branch
+inputs:
+  build-number:
+    description: LMS build number
+    required: true
+    type: string
+outputs:
+  branch:
+    description: Corresponding release branch or repository default branch
+    value: ${{steps.db.outputs.branch}}
+runs:
+  using: composite
+  steps:
+    - name: Validate build number
+      shell: bash
+      run: |
+        if [[ ! "$BUILD_NUMBER" =~ $BUILD_NUMBER_REGEX ]]; then
+            echo "Invalid build number format: $BUILD_NUMBER"
+            exit 1
+        fi
+      env:
+        BUILD_NUMBER: ${{inputs.build-number}}
+        BUILD_NUMBER_REGEX: ^([0-9]{2}\.){2}[0-9]{1,2}\.[0-9]{1,5}$
+    - name: Determine branch
+      id: db
+      shell: bash
+      run: |
+        RELEASE_MAJOR_MINOR=$(cut -d'.' -f1-2 <<< $BUILD_NUMBER)
+        RELEASE_MAJOR_MINOR=${RELEASE_MAJOR_MINOR//./}
+        RELEASE_PATCH=$(cut -d'.' -f3 <<< $BUILD_NUMBER)
+        BRANCH="release/$RELEASE_MAJOR_MINOR.$RELEASE_PATCH.x"
+        echo "Checking if the branch '$BRANCH' exists"
+        set +e
+        gh api \
+          --silent \
+          -H "Accept: application/vnd.github+json" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "repos/$GITHUB_REPOSITORY/branches/$BRANCH" >/dev/null 2>&1
+        EXIT_RESULT=$?
+        set -e
+        if [ $EXIT_RESULT -eq 0 ]; then
+          echo "Branch exist, using '$BRANCH' branch"
+        else
+          echo "Branch does not exist, using '$DEFAULT_BRANCH' branch"
+          BRANCH="$DEFAULT_BRANCH"
+        fi
+        echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+      env:
+        GITHUB_TOKEN: ${{github.token}}
+        BUILD_NUMBER: ${{inputs.build-number}}
+        DEFAULT_BRANCH: ${{github.event.repository.default_branch}}


### PR DESCRIPTION
Was doing this in a few spots for stuff that's triggered via `workflow_dispatch`. Since this trigger will always be done for the repository default branch we often want to switch/checkout a release branch before doing something like running tests. This centralizes the approach of getting the release branch. Seemed like this was the right spot for this since it's all around LMS version matching and release branches. Resolves https://github.com/Brightspace/lms-version-actions/issues/35.

[Example I'm hoping to replace.](https://github.com/Brightspace/playwright-ui-automation/blob/main/.github/workflows/nqc-post-lkg.yml#L78-L103)
Tested [here](https://github.com/Brightspace/playwright-ui-automation/compare/depowell/test).