### PR TITLE
Start posting failure comments

### DIFF
--- a/backport/action.yml
+++ b/backport/action.yml
@@ -172,7 +172,6 @@ runs:
       with:
         github-token: ${{ inputs.GITHUB_TOKEN }}
         script: |
-          console.log(${{ steps.destination-branch.outcome }});
           github.rest.issues.createComment({
             issue_number: context.payload.issue.number,
             owner: context.repo.owner,


### PR DESCRIPTION
This console message is causing the failure notification step to fail (lol). Removing as it doesn't seem very useful.

```
Error: Unhandled error: ReferenceError: success is not defined
```