### PR TITLE
LFT-2320: generate package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "lms-version-actions",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "lms-version-actions",
+            "version": "1.0.0",
+            "license": "Apache-2.0"
+        }
+    }
+}


### PR DESCRIPTION
Adds a package-lock.json file, as this repo contained a package.json
file at its root without a corresponding lock file for npm, pnpm, or yarn.

This lock file was generated with npm 11.6.2 using the following
command:

	npm install --before '2025-11-24T03:16:26Z' --package-lock-only
